### PR TITLE
Add PromptCompare condition

### DIFF
--- a/includes/Conditions/Prompt.php
+++ b/includes/Conditions/Prompt.php
@@ -5,7 +5,7 @@ namespace WP_Forge\WP_Scaffolding_Tool\Conditions;
 /**
  * Class Prompt
  */
-class PromptCompare extends AbstractCondition {
+class Prompt extends AbstractCondition {
 
 	/**
 	 * Validate condition properties.

--- a/includes/Conditions/PromptCompare.php
+++ b/includes/Conditions/PromptCompare.php
@@ -77,7 +77,6 @@ class PromptCompare extends AbstractCondition {
 			case 'eq':
 			case 'equals':
 			default:
-				
 				return $stored === $value;
 		}
 	}
@@ -91,7 +90,7 @@ class PromptCompare extends AbstractCondition {
 	 */
 	private function multitype_contains( $haystack, $needle ) {
 		if ( is_array( $haystack ) ) {
-			return in_array( $needle, $haystack );
+			return in_array( $needle, $haystack, true );
 		} elseif ( is_object( $haystack ) ) {
 			return property_exists( $haystack, $needle );
 		} elseif ( is_string( $haystack ) ) {
@@ -103,11 +102,11 @@ class PromptCompare extends AbstractCondition {
 
 	/**
 	 * Set the default comparison operator condition when a config doesn't provide it.
-	 * 
+	 *
 	 * Arrays and objects check contains.
 	 * Strings and otherwise check equals.
 	 *
-	 * @param mixed $stored
+	 * @param mixed $stored Stored value in $this->store to type-check.
 	 * @return string
 	 */
 	private function default_comparison_operator( $stored ) {

--- a/includes/Conditions/PromptCompare.php
+++ b/includes/Conditions/PromptCompare.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace WP_Forge\WP_Scaffolding_Tool\Conditions;
+
+/**
+ * Class Prompt
+ */
+class PromptCompare extends AbstractCondition {
+
+	/**
+	 * Validate condition properties.
+	 *
+	 * @return $this
+	 */
+	public function validate() {
+		if ( ! $this->has( 'key' ) ) {
+			$this->error( "Condition 'key' is missing for type: '{$this->get('condition')}'" );
+		}
+		if ( ! $this->has( 'value' ) ) {
+			$this->error( "Condition 'value' is missing for type: '{$this->get('condition')}'" );
+		}
+		if ( ! $this->store->has( $this->get( 'key' ) ) ) {
+			$this->error( "Store did not contain: '{$this->get('key')}'" );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Evaluate whether or not the key exists.
+	 *
+	 * @return bool
+	 */
+	public function evaluate() {
+		return $this->compare();
+	}
+
+	/**
+	 * Map comparison operators to logic.
+	 *
+	 * @return boolean
+	 */
+	private function compare() {
+		$stored = $this->store->get( $this->get( 'key' ) );
+		$value  = $this->get( 'value' );
+		$type   = $this->has( 'compare' ) ? strtolower( $this->get( 'compare' ) ) : $this->default_comparison_operator( $stored );
+		switch ( $type ) {
+			case 'contains':
+			case 'includes':
+			case 'in':
+				return $this->multitype_contains( $stored, $value );
+			case 'notcontains':
+			case 'notincludes':
+			case 'notin':
+			case 'nin':
+				return ! $this->multitype_contains( $stored, $value );
+			case '<':
+			case 'lt':
+				return $stored < $value;
+			case '<=':
+			case 'lte':
+				return $stored <= $value;
+			case '>':
+			case 'gt':
+				return $stored > $value;
+			case '>=':
+			case 'gte':
+				return $stored >= $value;
+			case '!=':
+			case '!==':
+			case 'ne':
+			case 'notequals':
+				return $stored !== $value;
+			case '===':
+			case '==':
+			case '=':
+			case 'eq':
+			case 'equals':
+			default:
+				
+				return $stored === $value;
+		}
+	}
+
+	/**
+	 * Detect needle within arrays, objects or strings.
+	 *
+	 * @param array|object|string|mixed $haystack Variable to search.
+	 * @param string|mixed              $needle Variable to find in haystack.
+	 * @return boolean
+	 */
+	private function multitype_contains( $haystack, $needle ) {
+		if ( is_array( $haystack ) ) {
+			return in_array( $needle, $haystack );
+		} elseif ( is_object( $haystack ) ) {
+			return property_exists( $haystack, $needle );
+		} elseif ( is_string( $haystack ) ) {
+			return stripos( $haystack, strtolower( $needle ) );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Set the default comparison operator condition when a config doesn't provide it.
+	 * 
+	 * Arrays and objects check contains.
+	 * Strings and otherwise check equals.
+	 *
+	 * @param mixed $stored
+	 * @return string
+	 */
+	private function default_comparison_operator( $stored ) {
+		if ( is_array( $stored ) || is_object( $stored ) ) {
+			return 'in';
+		}
+
+		return 'eq';
+	}
+}


### PR DESCRIPTION
## Proposed changes

* Adds `promptCompare` condition for use in `config.json`'s with `key`, `value` and `compare` options.
* Use flexible set of comparison operators including....
    *  `in`
    * `nin`
    * `lt`
    * `gt`
    * `lte`
    * `gte`
    * `ne`
    * `eq`
* When `$this->store( {{ key }} )` is an array or object, defaults to checking `in` the stored value, otherwise defaults to checking `eq`. This only applies when `compare` isn't supplied.
* At present, all comparison is using hard, type-strict comparison -- we can extend with soft comparison if need arises.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

<!-- - [x] I have read the [CONTRIBUTING](https://github.com/wp-forge/.github/blob/master/.github/CONTRIBUTING.md) doc -->
- [x] Linting and tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
