### PR TITLE
Add: `composerPackageInstalled` condition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     }
   ],
   "require": {
+    "ext-json": "*",
     "php": ">=7.3",
     "league/climate": "^3.7",
     "league/flysystem": "^2.1",

--- a/includes/Conditions/ComposerPackageInstalled.php
+++ b/includes/Conditions/ComposerPackageInstalled.php
@@ -28,8 +28,8 @@ class ComposerPackageInstalled extends AbstractCondition {
 		}
 
 		$composer = json_decode( file_get_contents( 'composer.json' ), true );
-		if ( isset( $composer['require'][ $this->args['package'] ] )
-			|| isset( $composer['require-dev'][ $this->args['package'] ] ) ) {
+		if ( isset( $composer['require'][ $this->get('package') ] )
+			|| isset( $composer['require-dev'][ $this->get('package') ] ) ) {
 			return true;
 		}
 
@@ -40,7 +40,7 @@ class ComposerPackageInstalled extends AbstractCondition {
 		$composerLock = json_decode( file_get_contents( 'composer.lock' ), true );
 
 		return in_array(
-			$this->args['package'],
+			$this->get('package'),
 			array_map(
 				function ( $package ) {
 					return $package['name'];

--- a/includes/Conditions/ComposerPackageInstalled.php
+++ b/includes/Conditions/ComposerPackageInstalled.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WP_Forge\WP_Scaffolding_Tool\Conditions;
+
+class ComposerPackageInstalled extends AbstractCondition {
+
+	/**
+	 * Validate condition properties.
+	 *
+	 * @return $this
+	 */
+	public function validate() {
+		if ( ! $this->has( 'package' ) ) {
+			$this->error( "Condition 'package' is missing for type: '{$this->get('condition')}'" );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Evaluate whether or not a package is required in Composer
+	 *
+	 * @return bool
+	 */
+	public function evaluate() {
+		if ( ! file_exists( 'composer.json' ) ) {
+			return false;
+		}
+
+		$composer = json_decode( file_get_contents( 'composer.json' ), true );
+		return isset( $composer['require'][ $this->args['package'] ] )
+			|| isset( $composer['require-dev'][ $this->args['package'] ] );
+	}
+}

--- a/includes/Conditions/ComposerPackageInstalled.php
+++ b/includes/Conditions/ComposerPackageInstalled.php
@@ -28,7 +28,25 @@ class ComposerPackageInstalled extends AbstractCondition {
 		}
 
 		$composer = json_decode( file_get_contents( 'composer.json' ), true );
-		return isset( $composer['require'][ $this->args['package'] ] )
-			|| isset( $composer['require-dev'][ $this->args['package'] ] );
+		if ( isset( $composer['require'][ $this->args['package'] ] )
+			|| isset( $composer['require-dev'][ $this->args['package'] ] ) ) {
+			return true;
+		}
+
+		if ( ! file_exists( 'composer.lock' ) ) {
+			return false;
+		}
+
+		$composerLock = json_decode( file_get_contents( 'composer.lock' ), true );
+
+		return in_array(
+			$this->args['package'],
+			array_map(
+				function ( $package ) {
+					return $package['name'];
+				},
+				array_merge( $composerLock['packages'], $composerLock['packages-dev'] )
+			)
+		);
 	}
 }

--- a/tests/unit/includes/Conditions/ComposerPackageInstalledTest.php
+++ b/tests/unit/includes/Conditions/ComposerPackageInstalledTest.php
@@ -161,4 +161,46 @@ EOD;
 
 		unlink( $tempDir . '/composer.json' );
 	}
+
+	/**
+	 * @covers ::validate
+	 * @covers ::evaluate
+	 */
+	public function test_validate_package_in_composer_lock(): void {
+		$container = $this->createMock( \WP_Forge\Container\Container::class );
+
+		$args = array(
+			'condition' => 'composerPackageInstalled',
+			'package'   => 'php-stubs/wordpress-stubs',
+		);
+
+		$composerLockJson = <<<EOD
+{
+    "packages": [
+        {
+            "name": "not-php-stubs/wordpress-stubs"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "php-stubs/wordpress-stubs"
+        }
+    ]
+}
+EOD;
+		$tempDir      = sys_get_temp_dir();
+		file_put_contents( $tempDir . '/composer.json', '{}' );
+		file_put_contents( $tempDir . '/composer.lock', $composerLockJson );
+		chdir( $tempDir );
+
+		$sut = ( new ComposerPackageInstalled( $container ) )->withArgs( $args );
+
+		$sut->validate();
+
+		$result = $sut->evaluate();
+
+		$this->assertTrue( $result );
+
+		unlink( $tempDir . '/composer.json' );
+	}
 }

--- a/tests/unit/includes/Conditions/ComposerPackageInstalledTest.php
+++ b/tests/unit/includes/Conditions/ComposerPackageInstalledTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace WP_Forge\WP_Scaffolding_Tool\Conditions;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \WP_Forge\WP_Scaffolding_Tool\Conditions\ComposerPackageInstalled
+ */
+class ComposerPackageInstalledTest extends TestCase {
+
+	/**
+	 * @covers ::validate
+	 */
+	public function test_validate_not_configured(): void {
+		$climate = new class() {
+			public function error( $message ) {
+				throw new \Exception( $message );
+			}
+		};
+
+		$container = $this->createMock( \WP_Forge\Container\Container::class );
+		$container->expects( $this->once() )
+			->method( 'get' )
+			->with( 'cli' )
+			->willReturn( $climate );
+
+		$args = array(
+			'condition' => 'composerPackageInstalled',
+		);
+
+		$sut = ( new ComposerPackageInstalled( $container ) )->withArgs( $args );
+
+		try {
+			$sut->validate();
+			$this->fail( 'Error not printed' );
+		} catch ( \Exception $exception ) {
+			$this->assertEquals( 'Condition \'package\' is missing for type: \'composerPackageInstalled\'', $exception->getMessage() );
+		}
+	}
+
+	/**
+	 * @covers ::validate
+	 * @covers ::evaluate
+	 */
+	public function test_validate_no_composer_json(): void {
+		$container = $this->createMock( \WP_Forge\Container\Container::class );
+
+		$args = array(
+			'condition' => 'composerPackageInstalled',
+			'package'   => 'php-stubs/wordpress-stubs',
+		);
+
+		$sut = ( new ComposerPackageInstalled( $container ) )->withArgs( $args );
+
+		$sut->validate();
+
+		$result = $sut->evaluate();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @covers ::validate
+	 * @covers ::evaluate
+	 */
+	public function test_validate_no_package_in_composer_json(): void {
+		$container = $this->createMock( \WP_Forge\Container\Container::class );
+
+		$args = array(
+			'condition' => 'composerPackageInstalled',
+			'package'   => 'php-stubs/wordpress-stubs',
+		);
+
+		$composerJson = <<<EOD
+{
+    "require": {
+        "not/php-stubs": "*"
+    }
+}
+EOD;
+		$tempDir      = sys_get_temp_dir();
+		file_put_contents( $tempDir . '/composer.json', $composerJson );
+		chdir( $tempDir );
+
+		$sut = ( new ComposerPackageInstalled( $container ) )->withArgs( $args );
+
+		$sut->validate();
+
+		$result = $sut->evaluate();
+
+		$this->assertFalse( $result );
+
+		unlink( $tempDir . '/composer.json' );
+	}
+
+	/**
+	 * @covers ::validate
+	 * @covers ::evaluate
+	 */
+	public function test_validate_package_in_require(): void {
+		$container = $this->createMock( \WP_Forge\Container\Container::class );
+
+		$args = array(
+			'condition' => 'composerPackageInstalled',
+			'package'   => 'php-stubs/wordpress-stubs',
+		);
+
+		$composerJson = <<<EOD
+{
+    "require": {
+        "php-stubs/wordpress-stubs": "*"
+    }
+}
+EOD;
+		$tempDir      = sys_get_temp_dir();
+		file_put_contents( $tempDir . '/composer.json', $composerJson );
+		chdir( $tempDir );
+
+		$sut = ( new ComposerPackageInstalled( $container ) )->withArgs( $args );
+
+		$sut->validate();
+
+		$result = $sut->evaluate();
+
+		$this->assertTrue( $result );
+
+		unlink( $tempDir . '/composer.json' );
+	}
+
+	/**
+	 * @covers ::validate
+	 * @covers ::evaluate
+	 */
+	public function test_validate_package_in_require_dev(): void {
+		$container = $this->createMock( \WP_Forge\Container\Container::class );
+
+		$args = array(
+			'condition' => 'composerPackageInstalled',
+			'package'   => 'php-stubs/wordpress-stubs',
+		);
+
+		$composerJson = <<<EOD
+{
+    "require-dev": {
+        "php-stubs/wordpress-stubs": "*"
+    }
+}
+EOD;
+		$tempDir      = sys_get_temp_dir();
+		file_put_contents( $tempDir . '/composer.json', $composerJson );
+		chdir( $tempDir );
+
+		$sut = ( new ComposerPackageInstalled( $container ) )->withArgs( $args );
+
+		$sut->validate();
+
+		$result = $sut->evaluate();
+
+		$this->assertTrue( $result );
+
+		unlink( $tempDir . '/composer.json' );
+	}
+}


### PR DESCRIPTION
## Proposed changes

When setting the WordPress version, we want to edit the `php-stubs/wordpress-stubs` package in Composer only if it's already there.

```json
{
  "description" : "Update PHP version for php-stubs/wordpress-stubs in composer.json",
  "conditions": [
    {
      "condition": "composerPackageInstalled",
      "package": "php-stubs/wordpress-stubs"
    }
  ],
  "action": "runCommand",
  "command": "composer require --dev php-stubs/wordpress-stubs:\"{{ module.wpversion }}\""
}
```

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- - [] I have read the [CONTRIBUTING](https://github.com/wp-forge/.github/blob/master/.github/CONTRIBUTING.md) doc -->
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
